### PR TITLE
Change pycognito version pinned

### DIFF
--- a/custom_components/cecotec_conga/manifest.json
+++ b/custom_components/cecotec_conga/manifest.json
@@ -5,7 +5,7 @@
     "documentation": "https://github.com/alemuro/ha-cecotec-conga",
     "issue_tracker": "https://github.com/alemuro/ha-cecotec-conga",
     "iot_class": "cloud_polling",
-    "requirements": ["pycognito==2022.5.0", "boto3>=1.24.26"],
+    "requirements": ["pycognito>=2022.7.0", "boto3>=1.24.26"],
     "codeowners": [
         "@alemuro"
     ],


### PR DESCRIPTION
After HA 2024.12 upgrade this started failing because this integration was reinstalling the pycognito package with an older version.